### PR TITLE
allow private/public subnets to be individually tagged

### DIFF
--- a/examples/eks-subnet-tagging/main.tf
+++ b/examples/eks-subnet-tagging/main.tf
@@ -1,0 +1,31 @@
+module "vpc" {
+  source = "../../"
+
+  name = "my-eks-cluster"
+
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19", "10.0.128.0/20", "10.0.144.0/20"]
+  public_subnets  = ["10.0.160.0/19", "10.0.192.0/19", "10.0.224.0/20", "10.0.240.0/20"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  private_subnet_tags = {
+    global = { foo = "bar" }
+    0 = { "kubernetes.io/cluster/my-eks-cluster-name" = "shared" }
+    1 = { "kubernetes.io/cluster/my-eks-cluster-name" = "shared" }
+    2 = { "kubernetes.io/cluster/my-eks-cluster-name" = "shared" }
+    3 = { "kubernetes.io/role/internal-elb" = 1 }
+    4 = { "component" = "some other component"}
+  }
+
+  public_subnet_tags = {
+    global = { foo = "bar" }
+    0 = { "kubernetes.io/cluster/my-eks-cluster-name" = "shared" }
+    1 = { "kubernetes.io/cluster/my-eks-cluster-name" = "shared" }
+    2 = { "kubernetes.io/cluster/my-eks-cluster-name" = "shared" }
+    3 = { "component" = "some other component"}
+  }
+}

--- a/examples/network-acls/main.tf
+++ b/examples/network-acls/main.tf
@@ -37,7 +37,7 @@ module "vpc" {
   single_nat_gateway = true
 
   public_subnet_tags = {
-    Name = "overridden-name-public"
+    global = { Name = "overridden-name-public" }
   }
 
   tags = {

--- a/examples/secondary-cidr-blocks/main.tf
+++ b/examples/secondary-cidr-blocks/main.tf
@@ -20,7 +20,7 @@ module "vpc" {
   single_nat_gateway = true
 
   public_subnet_tags = {
-    Name = "overridden-name-public"
+    global = { Name = "overridden-name-public"}
   }
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,18 @@ locals {
     var.tags,
     var.vpc_endpoint_tags,
   )
+
+  private_subnet_tags = merge(
+    { "global" = {} },
+    { for i in range(length(var.private_subnets)): i => {} },
+    var.private_subnet_tags
+  )
+
+  public_subnet_tags = merge(
+    { "global" = {} },
+    { for i in range(length(var.public_subnets)): i => {} },
+    var.public_subnet_tags
+  )
 }
 
 ######
@@ -301,7 +313,8 @@ resource "aws_subnet" "public" {
       )
     },
     var.tags,
-    var.public_subnet_tags,
+    local.public_subnet_tags["global"],
+    local.public_subnet_tags[count.index],
   )
 }
 
@@ -328,7 +341,8 @@ resource "aws_subnet" "private" {
       )
     },
     var.tags,
-    var.private_subnet_tags,
+    local.private_subnet_tags["global"],
+    local.private_subnet_tags[count.index],
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1726,14 +1726,14 @@ variable "igw_tags" {
 }
 
 variable "public_subnet_tags" {
-  description = "Additional tags for the public subnets"
-  type        = map(string)
+  description = "Additional tags for the public subnets. Keyed based on subnets, global tags will be applied to all subnets"
+  type        = map(map(string))
   default     = {}
 }
 
 variable "private_subnet_tags" {
-  description = "Additional tags for the private subnets"
-  type        = map(string)
+  description = "Additional tags for the private subnets. Keyed based on subnets, global tags will be applied to all subnets"
+  type        = map(map(string))
   default     = {}
 }
 


### PR DESCRIPTION
> # Description
> 
> Changed the private & public subnet tags to be a complex map. This allows private and public subnets to be individually tagged.
> 
> Addresses terraform-aws-modules/terraform-aws-vpc#259

Rebase on `master`/`v2.38.0` of PR terraform-aws-modules/terraform-aws-vpc#304
